### PR TITLE
Simplify catalog to static HTML/CSS/JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# catalogoigorvalen
+# Catálogo IgorValen
+
+Este repositório contém uma versão estática do catálogo da distribuidora **IgorValen**. A aplicação usa React via CDN com um bundle já compilado em JavaScript simples, funcionando somente com arquivos estáticos.
+
+## Estrutura
+
+```
+index.html   # página principal
+api.js       # implementação mock da API
+app.js       # aplicação React compilada
+styles.css   # estilos globais
+```
+
+Para visualizar o catálogo, basta abrir `index.html` em um navegador com acesso à internet.

--- a/api.js
+++ b/api.js
@@ -1,0 +1,188 @@
+// lib/api.js - mock API implementation
+
+const MOCK_PRODUCTS = [
+    {
+        id: 'p1',
+        name: 'Refrigerante Goob 2L',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '66', flavor: 'Cola' },
+            { code: '69', flavor: 'Guaraná' },
+            { code: '', flavor: 'Laranja' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+1',
+        sortOrder: 1,
+        active: true,
+    },
+    {
+        id: 'p2',
+        name: 'Energético Ener Up 250ML',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '49', flavor: 'Tradicional' },
+            { code: '', flavor: 'Tropical' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+2',
+        sortOrder: 2,
+        active: true,
+    },
+    {
+        id: 'p7',
+        name: 'Suco de Laranja 1L',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '71', flavor: 'Laranja' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+3',
+        sortOrder: 3,
+        active: true,
+    },
+    {
+        id: 'p4',
+        name: 'Cerveja Skol Lata 350ml',
+        category: 'Bebidas alcoólicas',
+        variants: [
+            { code: '150', flavor: 'Pilsen' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Alcoólica+1',
+        sortOrder: 4,
+        active: true,
+    },
+    {
+        id: 'p8',
+        name: 'Vinho Tinto Suave 750ml',
+        category: 'Bebidas alcoólicas',
+        variants: [
+            { code: '155', flavor: 'Tinto Suave' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Alcoólica+2',
+        sortOrder: 5,
+        active: true,
+    },
+    {
+        id: 'p3',
+        name: 'Bombom Garoto',
+        category: 'Bomboneire',
+        variants: [
+            { code: '101', flavor: 'Sortidos' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Doce+1',
+        sortOrder: 6,
+        active: true,
+    },
+    {
+        id: 'p9',
+        name: 'Chocolate Lacta 90g',
+        category: 'Bomboneire',
+        variants: [
+            { code: '105', flavor: 'Ao Leite' },
+            { code: '105B', flavor: 'Branco' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Doce+2',
+        sortOrder: 7,
+        active: true,
+    },
+    {
+        id: 'p5',
+        name: 'Rothmans Click',
+        category: 'Cigarro',
+        variants: [
+            { code: '201', flavor: 'Mentolado' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Cigarro+1',
+        sortOrder: 8,
+        active: true,
+    },
+    {
+        id: 'p6',
+        name: 'Isqueiro Bic',
+        category: 'Utilidades',
+        variants: [
+            { code: '301', flavor: 'Cores Sortidas' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Utilidade+1',
+        sortOrder: 9,
+        active: true,
+    },
+    {
+        id: 'p10',
+        name: 'Vela de Aniversário',
+        category: 'Utilidades',
+        variants: [
+            { code: '305', flavor: 'Número 0-9' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Utilidade+2',
+        sortOrder: 10,
+        active: true,
+    },
+];
+
+let MOCK_SETTINGS = {
+    id: 1,
+    categoriesOrder: ['Bebidas não alcoólicas', 'Bebidas alcoólicas', 'Bomboneire', 'Cigarro', 'Utilidades'],
+};
+
+const api = {
+    loginAdmin: async (password) => {
+        await new Promise(res => setTimeout(res, 500));
+        return { ok: password === '1234' };
+    },
+
+    getCatalog: async (q) => {
+        await new Promise(res => setTimeout(res, 500));
+        let products = MOCK_PRODUCTS.filter(p => p.active);
+        if (q && q.q) {
+            const searchTerm = q.q.toLowerCase();
+            products = products.filter(p =>
+                p.name.toLowerCase().includes(searchTerm) ||
+                p.variants.some(v => (v.code || '').toLowerCase().includes(searchTerm) || (v.flavor || '').toLowerCase().includes(searchTerm))
+            );
+        }
+        if (q && q.category) {
+            products = products.filter(p => p.category === q.category);
+        }
+        return { products, settings: MOCK_SETTINGS };
+    },
+
+    getAdminProducts: async () => {
+        await new Promise(res => setTimeout(res, 500));
+        return [...MOCK_PRODUCTS].sort((a, b) => a.sortOrder - b.sortOrder);
+    },
+
+    getProduct: async (id) => {
+        await new Promise(res => setTimeout(res, 500));
+        return MOCK_PRODUCTS.find(p => p.id === id) || null;
+    },
+
+    updateProduct: async (id, data) => {
+        await new Promise(res => setTimeout(res, 500));
+        const index = MOCK_PRODUCTS.findIndex(p => p.id === id);
+        if (index !== -1) {
+            MOCK_PRODUCTS[index] = { ...MOCK_PRODUCTS[index], ...data };
+            return { ...MOCK_PRODUCTS[index] };
+        }
+        return null;
+    },
+
+    createProduct: async (data) => {
+        await new Promise(res => setTimeout(res, 500));
+        const newProduct = { ...data, id: `p${Date.now()}`, sortOrder: MOCK_PRODUCTS.length + 1 };
+        MOCK_PRODUCTS.push(newProduct);
+        return newProduct;
+    },
+
+    reorderProducts: async (orderedProducts) => {
+        await new Promise(res => setTimeout(res, 500));
+        orderedProducts.forEach((p, index) => {
+            const mockProduct = MOCK_PRODUCTS.find(mp => mp.id === p.id);
+            if (mockProduct) {
+                mockProduct.sortOrder = index + 1;
+            }
+        });
+        return { ok: true };
+    },
+};
+
+window.api = api;
+window.MOCK_SETTINGS = MOCK_SETTINGS;
+

--- a/app.js
+++ b/app.js
@@ -1,0 +1,688 @@
+"use strict";
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _toConsumableArray(r) { return _arrayWithoutHoles(r) || _iterableToArray(r) || _unsupportedIterableToArray(r) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _iterableToArray(r) { if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r); }
+function _arrayWithoutHoles(r) { if (Array.isArray(r)) return _arrayLikeToArray(r); }
+function _slicedToArray(r, e) { return _arrayWithHoles(r) || _iterableToArrayLimit(r, e) || _unsupportedIterableToArray(r, e) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
+function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
+var _React = React,
+  useState = _React.useState,
+  useEffect = _React.useEffect,
+  useRef = _React.useRef,
+  createContext = _React.createContext,
+  useContext = _React.useContext;
+
+// Context for routing & auth
+var AppContext = createContext();
+var AppProvider = function AppProvider(_ref) {
+  var children = _ref.children;
+  var _useState = useState({
+      name: 'home'
+    }),
+    _useState2 = _slicedToArray(_useState, 2),
+    route = _useState2[0],
+    setRoute = _useState2[1];
+  var _useState3 = useState(false),
+    _useState4 = _slicedToArray(_useState3, 2),
+    isAdmin = _useState4[0],
+    setIsAdmin = _useState4[1];
+  var navigate = function navigate(name) {
+    var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var path = name === 'home' ? '/' : "/".concat(name);
+    window.history.pushState(params, '', path);
+    setRoute({
+      name: name,
+      params: params
+    });
+  };
+  useEffect(function () {
+    var handlePopState = function handlePopState(event) {
+      var path = window.location.pathname.slice(1);
+      setRoute({
+        name: path || 'home',
+        params: event.state || {}
+      });
+    };
+    window.addEventListener('popstate', handlePopState);
+    var path = window.location.pathname.slice(1);
+    if (path) setRoute({
+      name: path
+    });
+    return function () {
+      return window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+  var auth = {
+    isAdmin: isAdmin,
+    login: function login(password) {
+      return api.loginAdmin(password).then(function (res) {
+        if (res.ok) setIsAdmin(true);
+        return res;
+      });
+    },
+    logout: function logout() {
+      return setIsAdmin(false);
+    }
+  };
+  return /*#__PURE__*/React.createElement(AppContext.Provider, {
+    value: {
+      route: route,
+      navigate: navigate,
+      auth: auth
+    }
+  }, children);
+};
+var useApp = function useApp() {
+  return useContext(AppContext);
+};
+
+// Header component
+var Header = function Header() {
+  var _useApp = useApp(),
+    navigate = _useApp.navigate;
+  return /*#__PURE__*/React.createElement("header", {
+    className: "bg-green-600 sticky top-0 z-40 shadow-lg",
+    style: {
+      backgroundColor: 'var(--brand-green)'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "container mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-24"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "bg-white px-4 py-2 rounded-xl shadow"
+  }, /*#__PURE__*/React.createElement("a", {
+    href: "#",
+    onClick: function onClick(e) {
+      e.preventDefault();
+      navigate('home');
+    },
+    className: "flex items-baseline"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "text-3xl font-bold",
+    style: {
+      color: 'var(--brand-green)'
+    }
+  }, "Igor"), /*#__PURE__*/React.createElement("span", {
+    className: "text-3xl font-bold",
+    style: {
+      color: 'var(--brand-red)'
+    }
+  }, "Valen")), /*#__PURE__*/React.createElement("span", {
+    className: "block text-sm -mt-1 font-medium text-gray-800"
+  }, "Distribuidora")), /*#__PURE__*/React.createElement("div", {
+    className: "flex items-center space-x-6"
+  }, /*#__PURE__*/React.createElement("a", {
+    href: "#",
+    onClick: function onClick(e) {
+      e.preventDefault();
+      navigate('home');
+    },
+    className: "text-white font-semibold hover:text-green-200 transition-colors"
+  }, "Cat\xE1logo"), /*#__PURE__*/React.createElement("a", {
+    href: "#",
+    onClick: function onClick(e) {
+      e.preventDefault();
+      navigate('admin');
+    },
+    className: "text-white font-semibold hover:text-green-200 transition-colors"
+  }, "ADM"))));
+};
+
+// Product card
+var ProductCard = function ProductCard(_ref2) {
+  var product = _ref2.product;
+  var codes = product.variants.map(function (v) {
+    return v.code;
+  }).filter(Boolean);
+  var flavors = product.variants.map(function (v) {
+    return v.flavor;
+  }).filter(Boolean);
+  var codeLabel = codes.length > 1 ? 'Códigos' : 'Código';
+  return /*#__PURE__*/React.createElement("div", {
+    className: "bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col transition-shadow hover:shadow-lg"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "bg-gray-50 p-4 relative h-40"
+  }, codes.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "absolute bottom-2 right-2 bg-black bg-opacity-70 text-white text-xs font-bold px-2 py-1 rounded"
+  }, codeLabel, ": ", codes.join(', ')), /*#__PURE__*/React.createElement("img", {
+    loading: "lazy",
+    src: product.imageUrl,
+    alt: product.name,
+    className: "w-full h-full object-contain"
+  })), /*#__PURE__*/React.createElement("div", {
+    className: "p-4 flex-grow flex flex-col"
+  }, /*#__PURE__*/React.createElement("h3", {
+    className: "font-bold text-lg",
+    style: {
+      color: 'var(--brand-green)'
+    }
+  }, product.name), flavors.length > 0 && /*#__PURE__*/React.createElement("p", {
+    className: "text-sm font-semibold mb-2",
+    style: {
+      color: 'var(--brand-red)'
+    }
+  }, "Sabores: ", /*#__PURE__*/React.createElement("span", {
+    className: "font-normal text-gray-600"
+  }, flavors.join(', ')))));
+};
+
+// Home page
+var HomePage = function HomePage() {
+  var _useState5 = useState({
+      products: [],
+      settings: {
+        categoriesOrder: []
+      }
+    }),
+    _useState6 = _slicedToArray(_useState5, 2),
+    catalog = _useState6[0],
+    setCatalog = _useState6[1];
+  var _useState7 = useState(true),
+    _useState8 = _slicedToArray(_useState7, 2),
+    loading = _useState8[0],
+    setLoading = _useState8[1];
+  var _useState9 = useState(''),
+    _useState0 = _slicedToArray(_useState9, 2),
+    query = _useState0[0],
+    setQuery = _useState0[1];
+  var _useState1 = useState(null),
+    _useState10 = _slicedToArray(_useState1, 2),
+    activeCategory = _useState10[0],
+    setActiveCategory = _useState10[1];
+  useEffect(function () {
+    setLoading(true);
+    api.getCatalog({
+      q: query,
+      category: activeCategory
+    }).then(function (data) {
+      setCatalog(data);
+      setLoading(false);
+    });
+  }, [query, activeCategory]);
+  var groupedProducts = catalog.settings.categoriesOrder.map(function (category) {
+    return {
+      category: category,
+      products: catalog.products.filter(function (p) {
+        return p.category === category;
+      })
+    };
+  }).filter(function (group) {
+    return group.products.length > 0;
+  });
+  return /*#__PURE__*/React.createElement("div", {
+    className: "container mx-auto p-4 sm:p-6 lg:p-8"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "panel p-6 mb-8"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "flex flex-wrap items-center justify-between gap-4 mb-4"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "flex flex-wrap items-center gap-2"
+  }, /*#__PURE__*/React.createElement("button", {
+    onClick: function onClick() {
+      return setActiveCategory(null);
+    },
+    className: "px-4 py-2 text-sm font-semibold rounded-full transition-colors ".concat(!activeCategory ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200')
+  }, "Todas"), catalog.settings.categoriesOrder.map(function (cat) {
+    return /*#__PURE__*/React.createElement("button", {
+      key: cat,
+      onClick: function onClick() {
+        return setActiveCategory(cat);
+      },
+      className: "px-4 py-2 text-sm font-semibold rounded-full transition-colors ".concat(activeCategory === cat ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200')
+    }, cat);
+  }))), /*#__PURE__*/React.createElement("div", {
+    className: "relative"
+  }, /*#__PURE__*/React.createElement("input", {
+    type: "text",
+    placeholder: "Buscar por nome, categoria ou c\xF3digo...",
+    onChange: function onChange(e) {
+      return setQuery(e.target.value);
+    },
+    className: "w-full pl-4 pr-32 py-3 bg-white border border-gray-300 text-gray-900 rounded-xl focus:outline-none focus:ring-2 focus:ring-green-500"
+  }), /*#__PURE__*/React.createElement("button", {
+    className: "absolute top-1/2 right-2 transform -translate-y-1/2 bg-green-600 text-white font-semibold px-6 py-2 rounded-lg hover:bg-green-700"
+  }, "Buscar"))), loading ? /*#__PURE__*/React.createElement("div", {
+    className: "text-center text-white text-2xl font-bold"
+  }, "Carregando...") : groupedProducts.map(function (group) {
+    return /*#__PURE__*/React.createElement("div", {
+      key: group.category,
+      className: "mb-12"
+    }, /*#__PURE__*/React.createElement("h2", {
+      className: "text-3xl font-bold text-white mb-4",
+      style: {
+        textShadow: '1px 1px 3px rgba(0,0,0,0.5)'
+      }
+    }, group.category), /*#__PURE__*/React.createElement("div", {
+      className: "bg-white rounded-2xl shadow-lg p-4 sm:p-6"
+    }, /*#__PURE__*/React.createElement("div", {
+      className: "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6"
+    }, group.products.map(function (p) {
+      return /*#__PURE__*/React.createElement(ProductCard, {
+        key: p.id,
+        product: p
+      });
+    }))));
+  }));
+};
+
+// Admin login page
+var AdminLoginPage = function AdminLoginPage() {
+  var _useApp2 = useApp(),
+    navigate = _useApp2.navigate,
+    auth = _useApp2.auth;
+  var _useState11 = useState(''),
+    _useState12 = _slicedToArray(_useState11, 2),
+    password = _useState12[0],
+    setPassword = _useState12[1];
+  var _useState13 = useState(''),
+    _useState14 = _slicedToArray(_useState13, 2),
+    error = _useState14[0],
+    setError = _useState14[1];
+  var _useState15 = useState(false),
+    _useState16 = _slicedToArray(_useState15, 2),
+    loading = _useState16[0],
+    setLoading = _useState16[1];
+  var handleSubmit = function handleSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    auth.login(password).then(function (res) {
+      if (res.ok) navigate('admin/products');else {
+        setError('Senha incorreta.');
+        setLoading(false);
+      }
+    });
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    className: "flex justify-center items-center pt-20"
+  }, /*#__PURE__*/React.createElement("form", {
+    onSubmit: handleSubmit,
+    className: "panel p-8 w-full max-w-sm"
+  }, /*#__PURE__*/React.createElement("h1", {
+    className: "text-2xl font-bold text-center mb-6 text-gray-800"
+  }, "Bem-vindo de volta!"), /*#__PURE__*/React.createElement("input", {
+    type: "password",
+    value: password,
+    onChange: function onChange(e) {
+      return setPassword(e.target.value);
+    },
+    placeholder: "Digite a senha admin",
+    className: "w-full px-4 py-3 bg-white border-2 border-gray-300 text-gray-900 rounded-xl mb-4 focus:outline-none focus:border-green-500"
+  }), /*#__PURE__*/React.createElement("button", {
+    type: "submit",
+    disabled: loading,
+    className: "w-full bg-green-600 text-white font-bold py-3 rounded-xl hover:bg-green-700 disabled:bg-gray-400"
+  }, loading ? 'Entrando...' : 'Entrar'), error && /*#__PURE__*/React.createElement("p", {
+    className: "text-red-500 text-center mt-4"
+  }, error)));
+};
+
+// Admin product list page
+var AdminProductListPage = function AdminProductListPage() {
+  var _useApp3 = useApp(),
+    navigate = _useApp3.navigate;
+  var _useState17 = useState([]),
+    _useState18 = _slicedToArray(_useState17, 2),
+    products = _useState18[0],
+    setProducts = _useState18[1];
+  var _useState19 = useState(true),
+    _useState20 = _slicedToArray(_useState19, 2),
+    loading = _useState20[0],
+    setLoading = _useState20[1];
+  var sortableRef = useRef(null);
+  useEffect(function () {
+    api.getAdminProducts().then(function (data) {
+      setProducts(data);
+      setLoading(false);
+    });
+  }, []);
+  useEffect(function () {
+    if (sortableRef.current && !loading) {
+      new Sortable(sortableRef.current, {
+        animation: 150,
+        handle: '.sortable-handle',
+        ghostClass: 'sortable-ghost',
+        onEnd: function onEnd(evt) {
+          var newProducts = _toConsumableArray(products);
+          var _newProducts$splice = newProducts.splice(evt.oldIndex, 1),
+            _newProducts$splice2 = _slicedToArray(_newProducts$splice, 1),
+            movedItem = _newProducts$splice2[0];
+          newProducts.splice(evt.newIndex, 0, movedItem);
+          setProducts(newProducts);
+          api.reorderProducts(newProducts);
+        }
+      });
+    }
+  }, [loading, products]);
+  return /*#__PURE__*/React.createElement("div", {
+    className: "container mx-auto p-4 sm:p-6 lg:p-8"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "flex justify-between items-center mb-6"
+  }, /*#__PURE__*/React.createElement("h1", {
+    className: "text-3xl font-bold text-white",
+    style: {
+      textShadow: '1px 1px 3px rgba(0,0,0,0.5)'
+    }
+  }, "Produtos"), /*#__PURE__*/React.createElement("div", {
+    className: "flex gap-2"
+  }, /*#__PURE__*/React.createElement("button", {
+    onClick: function onClick() {
+      return navigate('admin/product/new');
+    },
+    className: "bg-green-600 text-white font-semibold px-4 py-2 rounded-lg hover:bg-green-700"
+  }, "Adicionar"), /*#__PURE__*/React.createElement("button", {
+    className: "bg-gray-200 text-gray-800 font-semibold px-4 py-2 rounded-lg hover:bg-gray-300"
+  }, "Importar CSV"))), /*#__PURE__*/React.createElement("div", {
+    className: "panel overflow-x-auto p-4"
+  }, /*#__PURE__*/React.createElement("table", {
+    className: "w-full text-left text-gray-800"
+  }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", {
+    className: "border-b border-gray-200"
+  }, /*#__PURE__*/React.createElement("th", {
+    className: "p-4 w-12"
+  }), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "Imagem"), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "Produto"), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "C\xF3digos"), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "Categoria"), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "Ativo"), /*#__PURE__*/React.createElement("th", {
+    className: "p-4"
+  }, "A\xE7\xF5es"))), /*#__PURE__*/React.createElement("tbody", {
+    ref: sortableRef
+  }, loading ? /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("td", {
+    colSpan: "7",
+    className: "p-4 text-center"
+  }, "Carregando...")) : products.map(function (p) {
+    return /*#__PURE__*/React.createElement("tr", {
+      key: p.id,
+      className: "border-b border-gray-200 last:border-b-0"
+    }, /*#__PURE__*/React.createElement("td", {
+      className: "p-4 text-center sortable-handle text-gray-400"
+    }, "\u2630"), /*#__PURE__*/React.createElement("td", {
+      className: "p-4"
+    }, /*#__PURE__*/React.createElement("img", {
+      src: p.imageUrl,
+      className: "w-12 h-12 object-contain rounded bg-gray-100 p-1"
+    })), /*#__PURE__*/React.createElement("td", {
+      className: "p-4 font-semibold"
+    }, p.name), /*#__PURE__*/React.createElement("td", {
+      className: "p-4"
+    }, p.variants.map(function (v) {
+      return v.code;
+    }).filter(Boolean).join(', ')), /*#__PURE__*/React.createElement("td", {
+      className: "p-4"
+    }, p.category), /*#__PURE__*/React.createElement("td", {
+      className: "p-4"
+    }, p.active ? 'Sim' : 'Não'), /*#__PURE__*/React.createElement("td", {
+      className: "p-4"
+    }, /*#__PURE__*/React.createElement("button", {
+      onClick: function onClick() {
+        return navigate('admin/product/edit', {
+          id: p.id
+        });
+      },
+      className: "bg-green-600 text-white px-3 py-1 rounded-md text-sm font-semibold"
+    }, "Editar")));
+  })))));
+};
+
+// Admin product edit page
+var AdminProductEditPage = function AdminProductEditPage() {
+  var _useApp4 = useApp(),
+    navigate = _useApp4.navigate,
+    route = _useApp4.route;
+  var id = route.params.id;
+  var _useState21 = useState(null),
+    _useState22 = _slicedToArray(_useState21, 2),
+    product = _useState22[0],
+    setProduct = _useState22[1];
+  var _useState23 = useState(true),
+    _useState24 = _slicedToArray(_useState23, 2),
+    loading = _useState24[0],
+    setLoading = _useState24[1];
+  var _useState25 = useState(null),
+    _useState26 = _slicedToArray(_useState25, 2),
+    imagePreview = _useState26[0],
+    setImagePreview = _useState26[1];
+  var fileInputRef = useRef(null);
+  var categories = MOCK_SETTINGS.categoriesOrder;
+  useEffect(function () {
+    if (id) {
+      api.getProduct(id).then(function (data) {
+        setProduct(_objectSpread(_objectSpread({}, data), {}, {
+          variants: data.variants || [{
+            code: '',
+            flavor: ''
+          }]
+        }));
+        if (data.imageUrl) setImagePreview(data.imageUrl);
+        setLoading(false);
+      });
+    } else {
+      setProduct({
+        name: '',
+        category: categories[0],
+        active: true,
+        variants: [{
+          code: '',
+          flavor: ''
+        }]
+      });
+      setLoading(false);
+    }
+  }, [id]);
+  var handleChange = function handleChange(e) {
+    var _e$target = e.target,
+      name = _e$target.name,
+      value = _e$target.value,
+      type = _e$target.type,
+      checked = _e$target.checked;
+    setProduct(function (p) {
+      return _objectSpread(_objectSpread({}, p), {}, _defineProperty({}, name, type === 'checkbox' ? checked : value));
+    });
+  };
+  var handleVariantChange = function handleVariantChange(index, field, value) {
+    setProduct(function (p) {
+      var variants = _toConsumableArray(p.variants);
+      variants[index] = _objectSpread(_objectSpread({}, variants[index]), {}, _defineProperty({}, field, value));
+      return _objectSpread(_objectSpread({}, p), {}, {
+        variants: variants
+      });
+    });
+  };
+  var addVariant = function addVariant() {
+    setProduct(function (p) {
+      return _objectSpread(_objectSpread({}, p), {}, {
+        variants: [].concat(_toConsumableArray(p.variants), [{
+          code: '',
+          flavor: ''
+        }])
+      });
+    });
+  };
+  var removeVariant = function removeVariant(index) {
+    setProduct(function (p) {
+      return _objectSpread(_objectSpread({}, p), {}, {
+        variants: p.variants.filter(function (_, i) {
+          return i !== index;
+        })
+      });
+    });
+  };
+  var handleImageChange = function handleImageChange(e) {
+    if (e.target.files && e.target.files[0]) {
+      var file = e.target.files[0];
+      setImagePreview(URL.createObjectURL(file));
+      console.log('Arquivo selecionado:', file.name);
+    }
+  };
+  var handleSave = function handleSave() {
+    var productData = _objectSpread(_objectSpread({}, product), {}, {
+      imageUrl: imagePreview
+    });
+    var promise = id ? api.updateProduct(id, productData) : api.createProduct(productData);
+    promise.then(function () {
+      return navigate('admin/products');
+    });
+  };
+  if (loading) return /*#__PURE__*/React.createElement("div", {
+    className: "text-center text-white text-2xl font-bold pt-20"
+  }, "Carregando...");
+  if (!product) return /*#__PURE__*/React.createElement("div", {
+    className: "text-center text-red-500 text-2xl font-bold pt-20"
+  }, "Produto n\xE3o encontrado.");
+  return /*#__PURE__*/React.createElement("div", {
+    className: "container mx-auto p-4 sm:p-6 lg:p-8"
+  }, /*#__PURE__*/React.createElement("h1", {
+    className: "text-3xl font-bold text-white mb-6",
+    style: {
+      textShadow: '1px 1px 3px rgba(0,0,0,0.5)'
+    }
+  }, id ? 'Editar Produto' : 'Adicionar Produto'), /*#__PURE__*/React.createElement("div", {
+    className: "panel p-8 text-gray-800"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "grid grid-cols-1 md:grid-cols-3 gap-6"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "md:col-span-2 space-y-6"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "grid grid-cols-1 sm:grid-cols-2 gap-6"
+  }, /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+    className: "block font-semibold mb-1"
+  }, "Nome"), /*#__PURE__*/React.createElement("input", {
+    type: "text",
+    name: "name",
+    value: product.name,
+    onChange: handleChange,
+    className: "w-full p-2 bg-gray-100 border border-gray-300 rounded-lg"
+  })), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+    className: "block font-semibold mb-1"
+  }, "Categoria"), /*#__PURE__*/React.createElement("select", {
+    name: "category",
+    value: product.category,
+    onChange: handleChange,
+    className: "w-full p-2 bg-gray-100 border border-gray-300 rounded-lg"
+  }, categories.map(function (cat) {
+    return /*#__PURE__*/React.createElement("option", {
+      key: cat,
+      value: cat
+    }, cat);
+  })))), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("label", {
+    className: "block font-semibold mb-1"
+  }, "C\xF3digos e Sabores"), product.variants.map(function (v, index) {
+    return /*#__PURE__*/React.createElement("div", {
+      key: index,
+      className: "flex gap-2 mb-2"
+    }, /*#__PURE__*/React.createElement("input", {
+      type: "text",
+      value: v.code,
+      onChange: function onChange(e) {
+        return handleVariantChange(index, 'code', e.target.value);
+      },
+      placeholder: "C\xF3digo",
+      className: "flex-1 p-2 bg-gray-100 border border-gray-300 rounded-lg"
+    }), /*#__PURE__*/React.createElement("input", {
+      type: "text",
+      value: v.flavor,
+      onChange: function onChange(e) {
+        return handleVariantChange(index, 'flavor', e.target.value);
+      },
+      placeholder: "Sabor",
+      className: "flex-1 p-2 bg-gray-100 border border-gray-300 rounded-lg"
+    }), /*#__PURE__*/React.createElement("button", {
+      type: "button",
+      onClick: function onClick() {
+        return removeVariant(index);
+      },
+      className: "text-red-600 font-bold px-2"
+    }, "\xD7"));
+  }), /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    onClick: addVariant,
+    className: "mt-2 bg-green-600 text-white font-semibold px-4 py-1 rounded-lg"
+  }, "Adicionar"))), /*#__PURE__*/React.createElement("div", {
+    className: "space-y-2"
+  }, /*#__PURE__*/React.createElement("label", {
+    className: "block font-semibold mb-1"
+  }, "Imagem do Produto"), /*#__PURE__*/React.createElement("div", {
+    className: "w-full h-48 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed"
+  }, imagePreview ? /*#__PURE__*/React.createElement("img", {
+    src: imagePreview,
+    alt: "Preview",
+    className: "h-full w-full object-contain rounded-lg"
+  }) : /*#__PURE__*/React.createElement("span", {
+    className: "text-gray-500"
+  }, "Pr\xE9-visualiza\xE7\xE3o")), /*#__PURE__*/React.createElement("input", {
+    type: "file",
+    accept: "image/*",
+    onChange: handleImageChange,
+    ref: fileInputRef,
+    className: "hidden"
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: function onClick() {
+      return fileInputRef.current.click();
+    },
+    className: "w-full bg-gray-200 text-gray-800 font-semibold py-2 rounded-lg hover:bg-gray-300"
+  }, "Adicionar Imagem"))), /*#__PURE__*/React.createElement("div", {
+    className: "mt-6 flex items-center justify-between"
+  }, /*#__PURE__*/React.createElement("label", {
+    className: "flex items-center gap-2"
+  }, /*#__PURE__*/React.createElement("input", {
+    type: "checkbox",
+    name: "active",
+    checked: product.active,
+    onChange: handleChange
+  }), " Ativo"), /*#__PURE__*/React.createElement("div", {
+    className: "flex gap-2"
+  }, /*#__PURE__*/React.createElement("button", {
+    onClick: function onClick() {
+      return navigate('admin/products');
+    },
+    className: "bg-gray-200 text-gray-800 font-semibold px-6 py-2 rounded-lg"
+  }, "Cancelar"), /*#__PURE__*/React.createElement("button", {
+    onClick: handleSave,
+    className: "bg-green-600 text-white font-semibold px-6 py-2 rounded-lg"
+  }, "Salvar")))));
+};
+
+// Main app component
+var App = function App() {
+  var _useApp5 = useApp(),
+    route = _useApp5.route,
+    auth = _useApp5.auth;
+  var renderPage = function renderPage() {
+    if (!auth.isAdmin && route.name.startsWith('admin')) {
+      return /*#__PURE__*/React.createElement(AdminLoginPage, null);
+    }
+    switch (route.name) {
+      case 'home':
+        return /*#__PURE__*/React.createElement(HomePage, null);
+      case 'admin':
+        return /*#__PURE__*/React.createElement(AdminLoginPage, null);
+      case 'admin/products':
+        return /*#__PURE__*/React.createElement(AdminProductListPage, null);
+      case 'admin/product/edit':
+        return /*#__PURE__*/React.createElement(AdminProductEditPage, null);
+      case 'admin/product/new':
+        return /*#__PURE__*/React.createElement(AdminProductEditPage, null);
+      default:
+        return /*#__PURE__*/React.createElement(HomePage, null);
+    }
+  };
+  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement(Header, null), /*#__PURE__*/React.createElement("main", null, renderPage()));
+};
+ReactDOM.render(/*#__PURE__*/React.createElement(AppProvider, null, /*#__PURE__*/React.createElement(App, null)), document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Catálogo - IgorValen Distribuidora</title>
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <!-- React & ReactDOM -->
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+
+    <!-- SortableJS for Drag-and-Drop -->
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <div id="root"></div>
+    <div class="wave-container"></div>
+
+    <script src="api.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,147 @@
+:root {
+    --brand-green: #0f8a3a;
+    --brand-green-darker: #0b5d29;
+    --brand-red: #de1f36;
+    --text: #111111;
+    --bg-soft: #f3f4f6;
+}
+
+html, body {
+    min-height: 100%;
+    font-family: 'Poppins', sans-serif;
+}
+
+body {
+    background-color: var(--brand-red);
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50vh;
+    min-height: 400px;
+    background: var(--brand-green);
+    clip-path: ellipse(100% 100% at 50% 0%);
+    z-index: 0;
+}
+
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg width='100' height='20' viewBox='0 0 100 20' xmlns='http://www.w3.org/2000/svg'><path d='M0 10 C 25 0, 75 20, 100 10' stroke='%23000000' stroke-width='0.5' fill='none' opacity='0.1'/></svg>");
+    background-size: 100px 20px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+#root {
+    position: relative;
+    z-index: 2;
+    padding-bottom: 200px;
+}
+
+.panel {
+    background: white;
+    border-radius: 1.5rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.category-wave-wrapper {
+    position: relative;
+    padding: 2rem 1.5rem;
+    border-radius: 1.5rem;
+    overflow: hidden;
+    background-color: var(--brand-green);
+}
+
+.category-wave-wrapper::before,
+.category-wave-wrapper::after {
+    content: '';
+    position: absolute;
+    left: -50%;
+    width: 200%;
+    height: 100%;
+    background: var(--brand-green-darker);
+    border-radius: 50%;
+    opacity: 0.3;
+    z-index: 0;
+}
+
+.category-wave-wrapper::before {
+    top: 10%;
+    transform: rotate(4deg);
+}
+
+.category-wave-wrapper::after {
+    bottom: 10%;
+    transform: rotate(-4deg);
+}
+
+.category-content {
+    position: relative;
+    z-index: 1;
+}
+
+.wave-container {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 300px;
+    z-index: 0;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.wave-container::before,
+.wave-container::after {
+    content: '';
+    position: absolute;
+    left: -50%;
+    width: 200%;
+    height: 100%;
+    border-radius: 50% 50% 0 0;
+    background: var(--brand-green);
+}
+
+.wave-container::after {
+    opacity: 0.7;
+    bottom: -200px;
+    transform: rotate(5deg);
+}
+
+.wave-container::before {
+    opacity: 1;
+    bottom: -220px;
+    transform: rotate(-3deg);
+}
+
+.toggle-checkbox:checked {
+    right: 0;
+    border-color: var(--brand-green);
+}
+
+.toggle-checkbox:checked + .toggle-label {
+    background-color: var(--brand-green);
+}
+
+.sortable-ghost {
+    opacity: 0.4;
+    background: #c8ebfb;
+    cursor: grabbing;
+}
+
+.sortable-drag {
+    opacity: 1 !important;
+    cursor: grabbing;
+}
+
+.sortable-handle {
+    cursor: grab;
+}


### PR DESCRIPTION
## Summary
- flatten project structure so CSS (`styles.css`), mock API (`api.js`) and React bundle (`app.js`) live alongside `index.html`
- remove unused source, lib and dist folders for a purely static catalog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce3b79fc833394e844930ef9a0f7