### PR TITLE
Modernize product site and drop admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# catalogoigorvalen
+# IgorValen Distribuidora
+
+Site estático de produtos da distribuidora **IgorValen**, feito apenas com HTML, CSS e JavaScript via CDN.
+
+## Estrutura
+
+```
+index.html   # página principal
+api.js       # implementação mock da API
+app.js       # aplicação React com React e Babel via CDN
+styles.css   # estilos globais
+```
+
+Para visualizar o catálogo, basta abrir `index.html` em um navegador com acesso à internet.

--- a/api.js
+++ b/api.js
@@ -1,0 +1,143 @@
+// lib/api.js - mock API implementation
+
+const MOCK_PRODUCTS = [
+    {
+        id: 'p1',
+        name: 'Refrigerante Goob 2L',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '66', flavor: 'Cola' },
+            { code: '69', flavor: 'Guaraná' },
+            { code: '', flavor: 'Laranja' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+1',
+        sortOrder: 1,
+        active: true,
+    },
+    {
+        id: 'p2',
+        name: 'Energético Ener Up 250ML',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '49', flavor: 'Tradicional' },
+            { code: '', flavor: 'Tropical' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+2',
+        sortOrder: 2,
+        active: true,
+    },
+    {
+        id: 'p7',
+        name: 'Suco de Laranja 1L',
+        category: 'Bebidas não alcoólicas',
+        variants: [
+            { code: '71', flavor: 'Laranja' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Bebida+3',
+        sortOrder: 3,
+        active: true,
+    },
+    {
+        id: 'p4',
+        name: 'Cerveja Skol Lata 350ml',
+        category: 'Bebidas alcoólicas',
+        variants: [
+            { code: '150', flavor: 'Pilsen' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Alcoólica+1',
+        sortOrder: 4,
+        active: true,
+    },
+    {
+        id: 'p8',
+        name: 'Vinho Tinto Suave 750ml',
+        category: 'Bebidas alcoólicas',
+        variants: [
+            { code: '155', flavor: 'Tinto Suave' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Alcoólica+2',
+        sortOrder: 5,
+        active: true,
+    },
+    {
+        id: 'p3',
+        name: 'Bombom Garoto',
+        category: 'Bomboneire',
+        variants: [
+            { code: '101', flavor: 'Sortidos' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Doce+1',
+        sortOrder: 6,
+        active: true,
+    },
+    {
+        id: 'p9',
+        name: 'Chocolate Lacta 90g',
+        category: 'Bomboneire',
+        variants: [
+            { code: '105', flavor: 'Ao Leite' },
+            { code: '105B', flavor: 'Branco' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Doce+2',
+        sortOrder: 7,
+        active: true,
+    },
+    {
+        id: 'p5',
+        name: 'Rothmans Click',
+        category: 'Cigarro',
+        variants: [
+            { code: '201', flavor: 'Mentolado' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Cigarro+1',
+        sortOrder: 8,
+        active: true,
+    },
+    {
+        id: 'p6',
+        name: 'Isqueiro Bic',
+        category: 'Utilidades',
+        variants: [
+            { code: '301', flavor: 'Cores Sortidas' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Utilidade+1',
+        sortOrder: 9,
+        active: true,
+    },
+    {
+        id: 'p10',
+        name: 'Vela de Aniversário',
+        category: 'Utilidades',
+        variants: [
+            { code: '305', flavor: 'Número 0-9' },
+        ],
+        imageUrl: 'https://placehold.co/400x400/e2e8f0/334155?text=Utilidade+2',
+        sortOrder: 10,
+        active: true,
+    },
+];
+
+let MOCK_SETTINGS = {
+    id: 1,
+    categoriesOrder: ['Bebidas não alcoólicas', 'Bebidas alcoólicas', 'Bomboneire', 'Cigarro', 'Utilidades'],
+};
+
+const api = {
+    getCatalog: async (q) => {
+        await new Promise(res => setTimeout(res, 500));
+        let products = MOCK_PRODUCTS.filter(p => p.active);
+        if (q && q.q) {
+            const searchTerm = q.q.toLowerCase();
+            products = products.filter(p =>
+                p.name.toLowerCase().includes(searchTerm) ||
+                p.variants.some(v => (v.code || '').toLowerCase().includes(searchTerm) || (v.flavor || '').toLowerCase().includes(searchTerm))
+            );
+        }
+        if (q && q.category) {
+            products = products.filter(p => p.category === q.category);
+        }
+        return { products, settings: MOCK_SETTINGS };
+    }
+};
+
+window.api = api;

--- a/app.js
+++ b/app.js
@@ -1,0 +1,124 @@
+const { useState, useEffect } = React;
+
+const CATEGORY_ICONS = {
+  "Bebidas não alcoólicas": "https://img.icons8.com/color/48/soda-can.png",
+  "Bebidas alcoólicas": "https://img.icons8.com/color/48/beer-bottle.png",
+  "Bomboneire": "https://img.icons8.com/color/48/chocolate-bar.png",
+  "Cigarro": "https://img.icons8.com/color/48/cigarette.png",
+  "Utilidades": "https://img.icons8.com/color/48/toolbox.png"
+};
+
+function ProductCard({ product }) {
+  const codes = product.variants.map(v => v.code).filter(Boolean).join(', ');
+  const flavors = product.variants.map(v => v.flavor).filter(Boolean).join(', ');
+  return (
+    <div className="bg-white rounded-3xl shadow-sm overflow-hidden flex flex-col transition-shadow hover:shadow-lg">
+      <div className="bg-gray-50 p-4 h-40 flex items-center justify-center">
+        <img loading="lazy" src={product.imageUrl} alt={product.name} className="w-full h-full object-contain" />
+      </div>
+      <div className="p-4 flex-grow flex flex-col">
+        <h3 className="font-bold text-lg" style={{color: 'var(--brand-green)'}}>{product.name}</h3>
+        {flavors && (
+          <p className="text-sm font-semibold" style={{color:'var(--brand-red)'}}>
+            Sabores: <span className="font-normal text-gray-600">{flavors}</span>
+          </p>
+        )}
+        {codes && (
+          <p className="text-sm font-semibold mt-1" style={{color:'var(--brand-green)'}}>
+            Códigos: <span className="font-normal text-gray-600">{codes}</span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HomePage() {
+  const [catalog, setCatalog] = useState({ products: [], settings: { categoriesOrder: [] } });
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    api.getCatalog({ q: query, category: activeCategory }).then(data => {
+      setCatalog(data);
+      setLoading(false);
+    });
+  }, [query, activeCategory]);
+
+  const grouped = catalog.settings.categoriesOrder.map(category => ({
+    category,
+    products: catalog.products.filter(p => p.category === category)
+  })).filter(g => g.products.length > 0);
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <div className="panel p-6 mb-8">
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <button onClick={() => setActiveCategory(null)} className={`px-4 py-2 text-sm font-semibold rounded-full transition-colors ${!activeCategory ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>Todas</button>
+            {catalog.settings.categoriesOrder.map(cat => (
+              <button key={cat} onClick={() => setActiveCategory(cat)} className={`flex items-center gap-1 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${activeCategory===cat ? 'bg-green-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>
+                <img src={CATEGORY_ICONS[cat]} alt="" className="w-4 h-4"/>
+                {cat}
+              </button>
+            ))}
+          </div>
+          <div className="relative w-full max-w-xs sm:max-w-sm">
+            <input type="text" placeholder="Buscar por nome, categoria ou código..." onChange={e=>setQuery(e.target.value)} className="w-full pl-4 pr-12 py-3 bg-white border border-gray-300 text-gray-900 rounded-full focus:outline-none focus:ring-2 focus:ring-green-500" />
+            <button className="absolute top-1/2 right-2 transform -translate-y-1/2 bg-green-600 text-white p-2 rounded-full hover:bg-green-700">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-4.35-4.35M17 10a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      {loading ? (
+        <div className="text-center text-white text-2xl font-bold">Carregando...</div>
+      ) : (
+        grouped.map(group => (
+          <div key={group.category} className="mb-12">
+            <h2 className="flex items-center text-3xl font-bold text-white mb-4" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>
+              <img src={CATEGORY_ICONS[group.category]} alt="" className="w-8 h-8 mr-2"/>
+              {group.category}
+            </h2>
+            <div className="bg-white rounded-3xl shadow-lg p-4 sm:p-6">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+                {group.products.map(p => <ProductCard key={p.id} product={p} />)}
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="bg-green-600 sticky top-0 z-40 shadow-lg" style={{backgroundColor:'var(--brand-green)'}}>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-center h-24">
+        <div className="bg-white px-4 py-2 rounded-2xl shadow">
+          <span className="text-3xl font-bold" style={{color:'var(--brand-green)'}}>Igor</span>
+          <span className="text-3xl font-bold" style={{color:'var(--brand-red)'}}>Valen</span>
+          <span className="block text-sm -mt-1 font-medium text-gray-800">Distribuidora</span>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function App() {
+  return (
+    <div>
+      <Header />
+      <main>
+        <HomePage />
+      </main>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IgorValen Distribuidora</title>
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <!-- React & ReactDOM -->
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <div id="root"></div>
+    <div class="wave-container"></div>
+
+    <script src="api.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" data-presets="env,react" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,124 @@
+:root {
+    --brand-green: #0f8a3a;
+    --brand-green-darker: #0b5d29;
+    --brand-red: #de1f36;
+    --text: #111111;
+    --bg-soft: #f3f4f6;
+}
+
+html, body {
+    min-height: 100%;
+    font-family: 'Poppins', sans-serif;
+}
+
+body {
+    background-color: var(--brand-red);
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50vh;
+    min-height: 400px;
+    background: var(--brand-green);
+    clip-path: ellipse(100% 100% at 50% 0%);
+    z-index: 0;
+}
+
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg width='100' height='20' viewBox='0 0 100 20' xmlns='http://www.w3.org/2000/svg'><path d='M0 10 C 25 0, 75 20, 100 10' stroke='%23000000' stroke-width='0.5' fill='none' opacity='0.1'/></svg>");
+    background-size: 100px 20px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+#root {
+    position: relative;
+    z-index: 2;
+    padding-bottom: 200px;
+}
+
+.panel {
+    background: white;
+    border-radius: 2rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.category-wave-wrapper {
+    position: relative;
+    padding: 2rem 1.5rem;
+    border-radius: 2rem;
+    overflow: hidden;
+    background-color: var(--brand-green);
+}
+
+.category-wave-wrapper::before,
+.category-wave-wrapper::after {
+    content: '';
+    position: absolute;
+    left: -50%;
+    width: 200%;
+    height: 100%;
+    background: var(--brand-green-darker);
+    border-radius: 50%;
+    opacity: 0.3;
+    z-index: 0;
+}
+
+.category-wave-wrapper::before {
+    top: 10%;
+    transform: rotate(4deg);
+}
+
+.category-wave-wrapper::after {
+    bottom: 10%;
+    transform: rotate(-4deg);
+}
+
+.category-content {
+    position: relative;
+    z-index: 1;
+}
+
+.wave-container {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 300px;
+    z-index: 0;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.wave-container::before,
+.wave-container::after {
+    content: '';
+    position: absolute;
+    left: -50%;
+    width: 200%;
+    height: 100%;
+    border-radius: 50% 50% 0 0;
+    background: var(--brand-green);
+}
+
+.wave-container::after {
+    opacity: 0.7;
+    bottom: -200px;
+    transform: rotate(5deg);
+}
+
+.wave-container::before {
+    opacity: 1;
+    bottom: -220px;
+    transform: rotate(-3deg);
+}
+


### PR DESCRIPTION
## Summary
- Remove admin panel and catalog label, leaving a public product viewer
- Introduce category icons and reposition codes below flavors for each product
- Add rounded modern styling and magnifying-glass search button
- Load Babel with React preset to render the catalog correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce3b79fc833394e844930ef9a0f7